### PR TITLE
Freetype linking

### DIFF
--- a/Sankore_3.1.pro
+++ b/Sankore_3.1.pro
@@ -369,6 +369,7 @@ linux-g++-32 {
 linux-g++-64 { 
     LIBS += -lcrypto
     LIBS += -lX11
+	LIBS += -lfreetype
     QMAKE_CFLAGS += -fopenmp
     QMAKE_CXXFLAGS += -fopenmp
     QMAKE_LFLAGS += -fopenmp


### PR DESCRIPTION
Freetype should be linked in Sankore_3-1.pro in order to fix the compilation process with linux-g++-64.
These modification concerns maybe linux-g++-32 too.
