### PR TITLE
Fix toolbar text state on app start.

### DIFF
--- a/src/core/UBApplication.cpp
+++ b/src/core/UBApplication.cpp
@@ -353,7 +353,7 @@ int UBApplication::exec(const QString& pFileToImport)
     connect(mainWindow->actionCheckUpdate, SIGNAL(triggered()), applicationController, SLOT(checkUpdateRequest()));
 
 
-
+    toolBarDisplayTextChanged(UBSettings::settings()->appToolBarDisplayText->get());
     toolBarPositionChanged(UBSettings::settings()->appToolBarPositionedAtTop->get());
 
     bool bUseMultiScreen = UBSettings::settings()->appUseMultiscreen->get().toBool();


### PR DESCRIPTION
When opening Sankoré, toolbar text state is not read from configuration, thus always displaying text even if user chooses not to. This should fix that. Untested because of unmet build dependencies.
